### PR TITLE
fix pom version to build 1.1.2 successfully

### DIFF
--- a/legacy/pom.xml
+++ b/legacy/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1.2</version>
     </parent>
 
     <groupId>com.googlecode.netlib-java</groupId>

--- a/native_ref/java/pom.xml
+++ b/native_ref/java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>native_ref-java</artifactId>

--- a/native_ref/osx-x86_64/pom.xml
+++ b/native_ref/osx-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-osx-x86_64</artifactId>

--- a/native_ref/pom.xml
+++ b/native_ref/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>native_ref</artifactId>

--- a/native_ref/win-i686/pom.xml
+++ b/native_ref/win-i686/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-win-i686</artifactId>

--- a/native_ref/win-x86_64/pom.xml
+++ b/native_ref/win-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-win-x86_64</artifactId>

--- a/native_ref/xbuilds/linux-armhf/pom.xml
+++ b/native_ref/xbuilds/linux-armhf/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-linux-armhf</artifactId>

--- a/native_ref/xbuilds/linux-i686/pom.xml
+++ b/native_ref/xbuilds/linux-i686/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-linux-i686</artifactId>

--- a/native_ref/xbuilds/linux-x86_64/pom.xml
+++ b/native_ref/xbuilds/linux-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_ref-linux-x86_64</artifactId>

--- a/native_ref/xbuilds/pom.xml
+++ b/native_ref/xbuilds/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>native_ref-xbuilds</artifactId>

--- a/native_system/java/pom.xml
+++ b/native_system/java/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>native_system-java</artifactId>

--- a/native_system/osx-x86_64/pom.xml
+++ b/native_system/osx-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-osx-x86_64</artifactId>

--- a/native_system/pom.xml
+++ b/native_system/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1.2</version>
     </parent>
 
     <artifactId>native_system</artifactId>

--- a/native_system/win-i686/pom.xml
+++ b/native_system/win-i686/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-win-i686</artifactId>

--- a/native_system/win-x86_64/pom.xml
+++ b/native_system/win-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-win-x86_64</artifactId>

--- a/native_system/xbuilds/linux-armhf/pom.xml
+++ b/native_system/xbuilds/linux-armhf/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-linux-armhf</artifactId>

--- a/native_system/xbuilds/linux-i686/pom.xml
+++ b/native_system/xbuilds/linux-i686/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-linux-i686</artifactId>

--- a/native_system/xbuilds/linux-x86_64/pom.xml
+++ b/native_system/xbuilds/linux-x86_64/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system-xbuilds</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>netlib-native_system-linux-x86_64</artifactId>

--- a/native_system/xbuilds/pom.xml
+++ b/native_system/xbuilds/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
-        <version>1.2-SNAPSHOT</version>
+        <version>1.1</version>
     </parent>
 
     <artifactId>native_system-xbuilds</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 
     <groupId>com.github.fommil.netlib</groupId>
     <artifactId>parent</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Currently, Spark use Breeze as its linear algebra library, while Breeze use netlib-java to call the native linear algebra library. In Spark1.1.0, it sitill use netlib-java version `1.1.2`. However, because the version of gcc in our cluster is a bit old, the pre-built netlib-java jar files do not fit our develop environment. Thus we come here to download source code then build our own `core-1.1.2.jar`, `native_system-java-1.1.jar`, `netlib-native_system-linux-x86_64-1.1-natives.jar` and so on.
Firstly,  `git checkout 1.1` ,then `mvn clean package`. No matter we choose `branch 1.1` or `tag 1.1.2` , both found errors. It is because netlib-java version in many `pom.xml` files do not correspond to the right version.
We have fix it, and build successfully to get the jars we want, then we create this pull request.
