### PR TITLE
PPC64LE natives

### DIFF
--- a/native_ref/xbuilds/linux-ppc64le/pom.xml
+++ b/native_ref/xbuilds/linux-ppc64le/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.fommil.netlib</groupId>
+        <artifactId>native_ref-xbuilds</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netlib-native_ref-linux-ppc64le</artifactId>
+    <packaging>so</packaging>
+
+    <!--
+    This is built natively for Linux ppc64le on an ppc64le architecture.
+    Ubuntu Wheezy is best as it compiles for GLIBC_2.2.5 whereas Ubuntu
+    requires the more recent GLIBC_2.13.
+
+      sudo apt-get install gfortran openjdk-7-jdk
+
+    It is impossible to compile a library on Ubuntu that has static
+    references to the fortran libraries, as the static fortran library
+    has not been compiled with -fPIC. The only workaround would be
+    to compile gcc from scratch, with the flags added, and then compile
+    these natives. That is not a wise move.
+    -->
+    <properties>
+        <netlib.src>../../../netlib</netlib.src>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>native_ref-java</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.fommil.netlib</groupId>
+                <artifactId>generator</artifactId>
+                <executions>
+                    <execution>
+                        <id>blas</id>
+                    </execution>
+                    <execution>
+                        <id>lapack</id>
+                    </execution>
+                    <execution>
+                        <id>arpack</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <javahOS>linux</javahOS>
+                    <linkerMiddleOptions>
+                        <linkerMiddleOption>-shared</linkerMiddleOption>
+                        <linkerMiddleOption>-lgfortran</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,-s</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--version-script=${netlib.src}/symbol.map</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--gc-sections</linkerMiddleOption>
+                    </linkerMiddleOptions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>runtime</id>
+                    </execution>
+                    <execution>
+                        <id>source</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/native_system/xbuilds/linux-ppc64le/pom.xml
+++ b/native_system/xbuilds/linux-ppc64le/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.fommil.netlib</groupId>
+        <artifactId>native_system-xbuilds</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netlib-native_system-linux-ppc64le</artifactId>
+    <packaging>so</packaging>
+
+    <!--
+    This is built natively for Linux ppc64le on an ppc64le architecture.
+    Ubuntu Wheezy is best as it compiles for GLIBC_2.2.5 whereas Ubuntu
+    requires the more recent GLIBC_2.13.
+
+      sudo apt-get install gfortran openjdk-7-jdk libblas-dev liblapack-dev
+
+    DO NOT INSTALL OPENBLAS at compile time or it will (unexplicably)
+    be added to the link path.
+
+    It is impossible to compile a library on Ubuntu that has static
+    references to the fortran libraries, as the static fortran library
+    has not been compiled with -fPIC. The only workaround would be
+    to compile gcc from scratch, with the flags added, and then compile
+    these natives. That is not a wise move.
+
+    Don't forget to enable your optimised system libraries at runtime!
+        (double dashes below... damn you XML!)
+
+        sudo update-alternatives - -config libblas.so.3
+        sudo update-alternatives - -config liblapack.so.3
+
+    see https://wiki.debian.org/DebianScience/LinearAlgebraLibraries for more.
+    -->
+    <properties>
+        <netlib.src>../../../netlib</netlib.src>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>native_system-java</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.fommil.netlib</groupId>
+                <artifactId>generator</artifactId>
+                <executions>
+                    <execution>
+                        <id>blas</id>
+                    </execution>
+                    <execution>
+                        <id>lapack</id>
+                    </execution>
+                    <execution>
+                        <id>arpack</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <javahOS>linux</javahOS>
+                    <linkerMiddleOptions>
+                        <linkerMiddleOption>-shared</linkerMiddleOption>
+                        <linkerMiddleOption>-lgfortran</linkerMiddleOption>
+                        <linkerMiddleOption>-lblas</linkerMiddleOption>
+                        <linkerMiddleOption>-llapack</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,-s</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--version-script=${netlib.src}/symbol.map</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--gc-sections</linkerMiddleOption>
+                    </linkerMiddleOptions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>runtime</id>
+                    </execution>
+                    <execution>
+                        <id>source</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Initial support for Linux ppc64le.  This provides the low level pom.xml files for native_ref and native_system, but does not alter the higher level config (so as not to break the existing build process).