### PR TITLE
Introduce maven profiles for ppc64le build convenience.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -25,77 +25,108 @@
             <artifactId>core</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+    </dependencies>
+
+    <profiles>
+      <profile>
+	<id>ppc64le-profile</id>
+	<activation>
+	  <os><arch>ppc64le</arch></os>
+	</activation>
+	<dependencies>
         <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-linux-ppc64le</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-linux-ppc64le</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+        </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>default-profile</id>
+	<activation>
+	  <activeByDefault>true</activeByDefault>
+	</activation>
+	<dependencies>
+	  <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-osx-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-linux-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-linux-i686</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-win-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-win-i686</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_ref-linux-armhf</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-osx-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-linux-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-linux-i686</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-linux-armhf</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-win-x86_64</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-        <dependency>
+          </dependency>
+          <dependency>
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>netlib-native_system-win-i686</artifactId>
             <version>${project.parent.version}</version>
             <classifier>natives</classifier>
-        </dependency>
-    </dependencies>
+          </dependency>
+	</dependencies>
+      </profile>
+    </profiles>
 </project>

--- a/native_ref/pom.xml
+++ b/native_ref/pom.xml
@@ -14,12 +14,20 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>java</module>
-        <module>osx-x86_64</module>
-        <module>win-i686</module>
-        <module>win-x86_64</module>
-        <!-- cross compiles are built separately on a Linux box... -->
+      <module>java</module>
     </modules>
+
+    <profiles>
+      <profile>
+	<id>default-profile</id>
+	<modules>
+          <module>osx-x86_64</module>
+          <module>win-i686</module>
+          <module>win-x86_64</module>
+          <!-- cross compiles are built separately on a Linux box... -->
+	</modules>
+      </profile>
+    </profiles>
 
     <properties>
         <natives>netlib-native_ref</natives>

--- a/native_ref/xbuilds/pom.xml
+++ b/native_ref/xbuilds/pom.xml
@@ -19,10 +19,27 @@
     <artifactId>native_ref-xbuilds</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>linux-x86_64</module>
-        <module>linux-i686</module>
-        <module>linux-armhf</module>
-    </modules>
+    <profiles>
+      <profile>
+	<id>ppc64le-profile</id>
+	<activation>
+	  <os><arch>ppc64le</arch></os>
+	</activation>
+	<modules>
+          <module>linux-ppc64le</module>
+	</modules>
+      </profile>
+      <profile>
+	<id>default-profile</id>
+	<activation>
+	  <activeByDefault>true</activeByDefault>
+	</activation>
+	<modules>
+          <module>linux-x86_64</module>
+          <module>linux-i686</module>
+          <module>linux-armhf</module>
+	</modules>
+      </profile>
+    </profiles>
 
 </project>

--- a/native_system/pom.xml
+++ b/native_system/pom.xml
@@ -22,12 +22,20 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>java</module>
-        <module>osx-x86_64</module>
-        <module>win-i686</module>
-        <module>win-x86_64</module>
-        <!-- cross compiles are built separately on a Linux box... -->
+      <module>java</module>
     </modules>
+
+    <profiles>
+      <profile>
+	<id>default-profile</id>
+	<modules>
+          <module>osx-x86_64</module>
+          <module>win-i686</module>
+          <module>win-x86_64</module>
+          <!-- cross compiles are built separately on a Linux box... -->
+	</modules>
+      </profile>
+    </profiles>
 
     <properties>
         <natives>netlib-native_system</natives>

--- a/native_system/xbuilds/pom.xml
+++ b/native_system/xbuilds/pom.xml
@@ -19,10 +19,27 @@
     <artifactId>native_system-xbuilds</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>linux-x86_64</module>
-        <module>linux-i686</module>
-        <module>linux-armhf</module>
-    </modules>
+    <profiles>
+      <profile>
+	<id>ppc64le-profile</id>
+	<activation>
+	  <os><arch>ppc64le</arch></os>
+	</activation>
+	<modules>
+          <module>linux-ppc64le</module>
+	</modules>
+      </profile>
+      <profile>
+	<id>default-profile</id>
+	<activation>
+	  <activeByDefault>true</activeByDefault>
+	</activation>
+	<modules>
+          <module>linux-x86_64</module>
+          <module>linux-i686</module>
+          <module>linux-armhf</module>
+	</modules>
+      </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,21 @@
     <version>1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <profiles>
+      <profile>
+	<id>ppc64le-profile</id>
+	<activation>
+	  <os><arch>ppc64le</arch></os>
+	</activation>
+      </profile>
+      <profile>
+	<id>default-profile</id>
+	<activation>
+	  <activeByDefault>true</activeByDefault>
+	</activation>
+      </profile>
+    </profiles>
+
     <modules>
         <module>core</module>
         <module>legacy</module>


### PR DESCRIPTION
This eliminates the need to edit pom.xml files to produce a ppc64le
build.  The default build process remains unchanged.

The correct profile is automatically activated based on the host
architecture such that, on ppc64le, it will build artifacts only for
that platform.