### PR TITLE
Support for linux AArch64 natives

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -29,6 +29,26 @@
 
     <profiles>
       <profile>
+	<id>aarch64-profile</id>
+	<activation>
+	  <os><arch>aarch64</arch></os>
+	</activation>
+	<dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-linux-aarch64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-linux-aarch64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+        </dependency>
+	</dependencies>
+      </profile>
+      <profile>
 	<id>ppc64le-profile</id>
 	<activation>
 	  <os><arch>ppc64le</arch></os>

--- a/native_ref/xbuilds/linux-aarch64/pom.xml
+++ b/native_ref/xbuilds/linux-aarch64/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.fommil.netlib</groupId>
+        <artifactId>native_ref-xbuilds</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netlib-native_ref-linux-aarch64</artifactId>
+    <packaging>so</packaging>
+
+    <!--
+    This is built natively for Linux aarch64 on an AArch64 architecture.
+
+    It is impossible to compile a library on Ubuntu that has static
+    references to the fortran libraries, as the static fortran library
+    has not been compiled with -fPIC. The only workaround would be
+    to compile gcc from scratch, with the flags added, and then compile
+    these natives. That is not a wise move.
+    -->
+    <properties>
+        <netlib.src>../../../netlib</netlib.src>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>native_ref-java</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.fommil.netlib</groupId>
+                <artifactId>generator</artifactId>
+                <executions>
+                    <execution>
+                        <id>blas</id>
+                    </execution>
+                    <execution>
+                        <id>lapack</id>
+                    </execution>
+                    <execution>
+                        <id>arpack</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <javahOS>linux</javahOS>
+                    <linkerMiddleOptions>
+                        <linkerMiddleOption>-shared</linkerMiddleOption>
+                        <linkerMiddleOption>-lgfortran</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,-s</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--version-script=${netlib.src}/symbol.map</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--gc-sections</linkerMiddleOption>
+                    </linkerMiddleOptions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>runtime</id>
+                    </execution>
+                    <execution>
+                        <id>source</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/native_ref/xbuilds/pom.xml
+++ b/native_ref/xbuilds/pom.xml
@@ -21,6 +21,15 @@
 
     <profiles>
       <profile>
+	<id>aarch64-profile</id>
+	<activation>
+	  <os><arch>aarch64</arch></os>
+	</activation>
+	<modules>
+          <module>linux-aarch64</module>
+	</modules>
+      </profile>
+      <profile>
 	<id>ppc64le-profile</id>
 	<activation>
 	  <os><arch>ppc64le</arch></os>

--- a/native_system/xbuilds/linux-aarch64/pom.xml
+++ b/native_system/xbuilds/linux-aarch64/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.fommil.netlib</groupId>
+        <artifactId>native_system-xbuilds</artifactId>
+        <version>1.2-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>netlib-native_system-linux-aarch64</artifactId>
+    <packaging>so</packaging>
+
+    <!--
+    This is built natively for Linux aarch64 on an AArch64 architecture.
+
+    DO NOT INSTALL OPENBLAS at compile time or it will (unexplicably)
+    be added to the link path.
+
+    It is impossible to compile a library on Ubuntu that has static
+    references to the fortran libraries, as the static fortran library
+    has not been compiled with -fPIC. The only workaround would be
+    to compile gcc from scratch, with the flags added, and then compile
+    these natives. That is not a wise move.
+
+    Don't forget to enable your optimised system libraries at runtime!
+        (double dashes below... damn you XML!)
+
+        sudo update-alternatives - -config libblas.so.3
+        sudo update-alternatives - -config liblapack.so.3
+    -->
+    <properties>
+        <netlib.src>../../../netlib</netlib.src>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>native_system-java</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.fommil.netlib</groupId>
+                <artifactId>generator</artifactId>
+                <executions>
+                    <execution>
+                        <id>blas</id>
+                    </execution>
+                    <execution>
+                        <id>lapack</id>
+                    </execution>
+                    <execution>
+                        <id>arpack</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>native-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <javahOS>linux</javahOS>
+                    <linkerMiddleOptions>
+                        <linkerMiddleOption>-shared</linkerMiddleOption>
+                        <linkerMiddleOption>-lgfortran</linkerMiddleOption>
+                        <linkerMiddleOption>-lblas</linkerMiddleOption>
+                        <linkerMiddleOption>-llapack</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,-s</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--version-script=${netlib.src}/symbol.map</linkerMiddleOption>
+                        <linkerMiddleOption>-Wl,--gc-sections</linkerMiddleOption>
+                    </linkerMiddleOptions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>runtime</id>
+                    </execution>
+                    <execution>
+                        <id>source</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/native_system/xbuilds/pom.xml
+++ b/native_system/xbuilds/pom.xml
@@ -21,6 +21,15 @@
 
     <profiles>
       <profile>
+	<id>aarch64-profile</id>
+	<activation>
+	  <os><arch>aarch64</arch></os>
+	</activation>
+	<modules>
+          <module>linux-aarch64</module>
+	</modules>
+      </profile>
+      <profile>
 	<id>ppc64le-profile</id>
 	<activation>
 	  <os><arch>ppc64le</arch></os>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
 
     <profiles>
       <profile>
+	<id>aarch64-profile</id>
+	<activation>
+	  <os><arch>aarch64</arch></os>
+	</activation>
+      </profile>
+      <profile>
 	<id>ppc64le-profile</id>
 	<activation>
 	  <os><arch>ppc64le</arch></os>


### PR DESCRIPTION
This is the support for Linux AArch64 natives.  It also introduces maven profiles for AArch64 build convenience just like pull requsets#111 do . 

This does not effect on higher level config and the default build process remains unchanged.

It will automatically build artifacts only for the specific platform, which is based on the host architecture such as AArch64, ppcle64, x86_64, etc.

My Hardware Environments:  Cavium ThunderX and Hisilicon Taishan ( AArch64 server) ,  
OS name: "linux", version: "4.4.0-15-generic", arch: "aarch64", family: "unix"