### PR TITLE
Build and diagnostics fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.ear
 *.iml
 
+# Targets
+target/

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>all</artifactId>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -32,7 +32,10 @@
       <profile>
 	<id>aarch64-profile</id>
 	<activation>
-	  <os><arch>aarch64</arch></os>
+	  <os>
+	    <name>linux</name>
+	    <arch>aarch64</arch>
+	  </os>
 	</activation>
 	<dependencies>
         <dependency>
@@ -52,7 +55,10 @@
       <profile>
 	<id>ppc64le-profile</id>
 	<activation>
-	  <os><arch>ppc64le</arch></os>
+	  <os>
+	    <name>linux</name>
+	    <arch>ppc64le</arch>
+	  </os>
 	</activation>
 	<dependencies>
         <dependency>
@@ -70,10 +76,145 @@
 	</dependencies>
       </profile>
       <profile>
-	<id>default-profile</id>
+        <id>linux-x86_64</id>
 	<activation>
-	  <activeByDefault>true</activeByDefault>
+	  <os>
+	    <name>linux</name>
+	    <arch>amd64</arch>
+	  </os>
 	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-linux-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-linux-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>osx-x86_64</id>
+	<activation>
+	  <os>
+	    <family>mac</family>
+	    <arch>x86_64</arch>
+	  </os>
+	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-osx-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	  <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-osx-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>linux-i686</id>
+	<activation>
+	  <os>
+	    <name>linux</name>
+	    <arch>i686</arch>
+	  </os>
+	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-linux-i686</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-linux-i686</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>win-x86_64</id>
+	<activation>
+	  <os>
+            <family>windows</family>
+	    <arch>amd64</arch>
+	  </os>
+	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-win-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-win-x86_64</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>win-i686</id>
+	<activation>
+	  <os>
+	    <name>win</name>
+	    <arch>i686</arch>
+	  </os>
+	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-win-i686</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-win-i686</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>linux-armhf</id>
+	<activation>
+	  <os>
+	    <name>linux</name>
+	    <arch>armhf</arch>
+	  </os>
+	</activation>
+	<dependencies>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_system-linux-armhf</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+          <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>netlib-native_ref-linux-armhf</artifactId>
+            <version>${project.parent.version}</version>
+            <classifier>natives</classifier>
+          </dependency>
+	</dependencies>
+      </profile>
+      <profile>
+	<id>default-profile</id>
 	<dependencies>
 	  <dependency>
             <groupId>${project.parent.groupId}</groupId>

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,17 @@
+@echo off
+
+cd "%~dp0"
+rem Build and install the generator
+pushd generator
+mvn clean && mvn install %*
+if ERRORLEVEL 1 (
+   popd
+   goto error
+)
+popd
+rem Build and install the actual project
+mvn clean && mvn install %*
+if errorlevel 1 goto error
+exit /b 0
+:error
+exit /b 1

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+(cd generator && mvn clean && mvn install "$@") &&
+mvn clean &&
+mvn install "$@"

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -133,7 +133,7 @@
     <!-- mvn versions:display-plugin-updates -->
     <build>
         <plugins>
-            <plugin>
+           <!--   <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.4</version>
@@ -146,7 +146,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/generator/src/main/resources/com/github/fommil/netlib/generator/netlib-java.stg
+++ b/generator/src/main/resources/com/github/fommil/netlib/generator/netlib-java.stg
@@ -84,6 +84,8 @@ public abstract class $name$ {
           break;
         } catch (Throwable e) {
           log.warning("Failed to load implementation from: " + className);
+          log.warning("Error was: " + e.toString());
+          e.printStackTrace();
         }
       }
       if (impl == null) {

--- a/native_ref/java/pom.xml
+++ b/native_ref/java/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_ref-java</artifactId>

--- a/native_ref/osx-x86_64/pom.xml
+++ b/native_ref/osx-x86_64/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_ref-osx-x86_64</artifactId>

--- a/native_ref/pom.xml
+++ b/native_ref/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_ref</artifactId>
@@ -26,6 +27,37 @@
           <module>win-x86_64</module>
           <!-- cross compiles are built separately on a Linux box... -->
 	</modules>
+      </profile>
+      <profile>
+        <id>windows</id>
+        <activation>
+          <os><name>windows</name></os>
+        </activation>
+        <modules>
+          <module>win-i686</module>
+          <module>win-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>osx</id>
+        <activation>
+          <os>
+            <name>osx</name>
+            <arch>amd64</arch>
+          </os>
+        </activation>
+        <modules>
+          <module>osx-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>linux</id>
+        <activation>
+          <os><name>linux</name></os>
+        </activation>
+        <modules>
+          <module>xbuilds</module>
+        </modules>
       </profile>
     </profiles>
 

--- a/native_ref/pom.xml
+++ b/native_ref/pom.xml
@@ -31,7 +31,7 @@
       <profile>
         <id>windows</id>
         <activation>
-          <os><name>windows</name></os>
+          <os><family>windows</family></os>
         </activation>
         <modules>
           <module>win-i686</module>
@@ -42,8 +42,8 @@
         <id>osx</id>
         <activation>
           <os>
-            <name>osx</name>
-            <arch>amd64</arch>
+            <family>mac</family>
+            <arch>x86_64</arch>
           </os>
         </activation>
         <modules>

--- a/native_ref/win-i686/pom.xml
+++ b/native_ref/win-i686/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_ref-win-i686</artifactId>

--- a/native_ref/win-x86_64/pom.xml
+++ b/native_ref/win-x86_64/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_ref-win-x86_64</artifactId>

--- a/native_ref/xbuilds/pom.xml
+++ b/native_ref/xbuilds/pom.xml
@@ -14,6 +14,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_ref</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_ref-xbuilds</artifactId>
@@ -39,10 +40,34 @@
 	</modules>
       </profile>
       <profile>
+        <id>x86_64-profile</id>
+        <activation>
+          <os><arch>amd64</arch></os>
+        </activation>
+        <modules>
+          <module>linux-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>i386-profile</id>
+        <activation>
+          <os><arch>i386</arch></os>
+        </activation>
+        <modules>
+          <module>linux-i386</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>armhf-profile</id>
+        <activation>
+          <os><arch>arm</arch></os>
+        </activation>
+        <modules>
+          <module>linux-armhf</module>
+        </modules>
+      </profile>
+      <profile>
 	<id>default-profile</id>
-	<activation>
-	  <activeByDefault>true</activeByDefault>
-	</activation>
 	<modules>
           <module>linux-x86_64</module>
           <module>linux-i686</module>

--- a/native_system/java/pom.xml
+++ b/native_system/java/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_system-java</artifactId>

--- a/native_system/osx-x86_64/pom.xml
+++ b/native_system/osx-x86_64/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_system-osx-x86_64</artifactId>

--- a/native_system/pom.xml
+++ b/native_system/pom.xml
@@ -39,7 +39,7 @@
       <profile>
         <id>windows</id>
         <activation>
-          <os><name>windows</name></os>
+          <os><family>windows</family></os>
         </activation>
         <modules>
           <module>win-i686</module>
@@ -50,7 +50,7 @@
         <id>osx</id>
         <activation>
           <os>
-            <name>osx</name>
+            <family>mac</family>
             <arch>x86_64</arch>
           </os>
         </activation>

--- a/native_system/pom.xml
+++ b/native_system/pom.xml
@@ -16,6 +16,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>parent</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_system</artifactId>
@@ -34,6 +35,37 @@
           <module>win-x86_64</module>
           <!-- cross compiles are built separately on a Linux box... -->
 	</modules>
+      </profile>
+      <profile>
+        <id>windows</id>
+        <activation>
+          <os><name>windows</name></os>
+        </activation>
+        <modules>
+          <module>win-i686</module>
+          <module>win-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>osx</id>
+        <activation>
+          <os>
+            <name>osx</name>
+            <arch>x86_64</arch>
+          </os>
+        </activation>
+        <modules>
+          <module>osx-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>linux</id>
+        <activation>
+          <os><name>linux</name></os>
+        </activation>
+        <modules>
+          <module>xbuilds</module>
+        </modules>
       </profile>
     </profiles>
 

--- a/native_system/win-i686/pom.xml
+++ b/native_system/win-i686/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_system-win-i686</artifactId>

--- a/native_system/win-x86_64/pom.xml
+++ b/native_system/win-x86_64/pom.xml
@@ -8,6 +8,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>netlib-native_system-win-x86_64</artifactId>

--- a/native_system/xbuilds/pom.xml
+++ b/native_system/xbuilds/pom.xml
@@ -14,6 +14,7 @@
         <groupId>com.github.fommil.netlib</groupId>
         <artifactId>native_system</artifactId>
         <version>1.2-SNAPSHOT</version>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>native_system-xbuilds</artifactId>
@@ -39,10 +40,34 @@
 	</modules>
       </profile>
       <profile>
+        <id>x86_64-profile</id>
+        <activation>
+          <os><arch>amd64</arch></os>
+        </activation>
+        <modules>
+          <module>linux-x86_64</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>i386-profile</id>
+        <activation>
+          <os><arch>i386</arch></os>
+        </activation>
+        <modules>
+          <module>linux-i386</module>
+        </modules>
+      </profile>
+      <profile>
+        <id>armhf-profile</id>
+        <activation>
+          <os><arch>armhf</arch></os>
+        </activation>
+        <modules>
+          <module>linux-armhf</module>
+        </modules>
+      </profile>
+      <profile>
 	<id>default-profile</id>
-	<activation>
-	  <activeByDefault>true</activeByDefault>
-	</activation>
 	<modules>
           <module>linux-x86_64</module>
           <module>linux-i686</module>

--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,54 @@
       </profile>
       <profile>
 	<id>default-profile</id>
-	<activation>
-	  <activeByDefault>true</activeByDefault>
-	</activation>
+      </profile>
+      <profile>
+        <id>windows</id>
+        <activation>
+          <os><name>windows</name></os>
+        </activation>
+      </profile>
+      <profile>
+        <id>osx</id>
+        <activation>
+          <os>
+            <name>osx</name>
+            <arch>amd64</arch>
+          </os>
+        </activation>
+      </profile>
+      <profile>
+        <id>linux</id>
+        <activation>
+          <os><name>linux</name></os>
+        </activation>
+      </profile>
+      <profile>
+        <id>x86_64-profile</id>
+        <activation>
+          <os>
+            <name>linux</name>
+            <arch>amd64</arch>
+          </os>
+        </activation>
+      </profile>
+      <profile>
+        <id>i386-profile</id>
+        <activation>
+          <os>
+            <name>linux</name>
+            <arch>i386</arch>
+          </os>
+        </activation>
+      </profile>
+      <profile>
+        <id>armhf-profile</id>
+        <activation>
+          <os>
+            <name>linux</name>
+            <arch>arm</arch>
+          </os>
+        </activation>
       </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,19 @@
       <profile>
 	<id>aarch64-profile</id>
 	<activation>
-	  <os><arch>aarch64</arch></os>
+          <os>
+            <name>linux</name>
+            <arch>aarch64</arch>
+          </os>
 	</activation>
       </profile>
       <profile>
 	<id>ppc64le-profile</id>
 	<activation>
-	  <os><arch>ppc64le</arch></os>
+	  <os>
+            <name>linux</name>
+            <arch>ppc64le</arch>
+          </os>
 	</activation>
       </profile>
       <profile>
@@ -79,15 +85,15 @@
       <profile>
         <id>windows</id>
         <activation>
-          <os><name>windows</name></os>
+          <os><family>windows</family></os>
         </activation>
       </profile>
       <profile>
         <id>osx</id>
         <activation>
           <os>
-            <name>osx</name>
-            <arch>amd64</arch>
+            <family>mac</family>
+            <arch>x86_64</arch>
           </os>
         </activation>
       </profile>
@@ -131,6 +137,7 @@
         <module>legacy</module>
         <module>native_ref</module>
         <module>native_system</module>
+        <module>all</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR provides several fixes to the build system and to diagnostics.

1. Running `mvn compile` in the Git repo root failed to build the native libraries (#119).  Fixed by selecting the correct architecture- and OS- specific profile to run.
2. The error message on failure to load optimized implementations is useless (#120).  Fixed by both logging the name of the exception and calling `printStackTrace()` on it.
3. Making a fully-clean build from Git is not easy, due to the need to clean and rebuild the generator, then clean and rebuild the actual project.  Fixed by providing `build.sh` and `build.cmd` scripts for that purpose.

Fixes #119.
Fixes #120.